### PR TITLE
Do not unmap shared buffer until a reply is sent

### DIFF
--- a/src/kernel/capabilities/rose-kernel-capabilities-reply.adb
+++ b/src/kernel/capabilities/rose-kernel-capabilities-reply.adb
@@ -27,7 +27,7 @@ package body Rose.Kernel.Capabilities.Reply is
          Rose.Boot.Console.Put (": receiver is not waiting for reply");
          Rose.Boot.Console.New_Line;
       else
-         Rose.Kernel.Processes.Unmap_Invocation_Buffer (From_Pid);
+         Rose.Kernel.Processes.Unmap_Invocation_Buffer (From_Pid, To_Pid);
          Rose.Kernel.Processes.Send_Reply
            (From_Pid, To_Pid, Params.all);
       end if;

--- a/src/kernel/processes/rose-kernel-processes-init.adb
+++ b/src/kernel/processes/rose-kernel-processes-init.adb
@@ -50,10 +50,15 @@ package body Rose.Kernel.Processes.Init is
              (System'To_Address (Table_Address)));
 
       for I in Process_Table'Range loop
-         Process_Table (I).Pid := I;
-         Process_Table (I).Oid := Rose.Objects.Null_Object_Id;
-         Process_Table (I).State := Available;
-         Process_Table (I).Name := (others => ' ');
+         declare
+            P : Kernel_Process_Entry renames Process_Table (I);
+         begin
+            P.Pid := I;
+            P.Oid := Rose.Objects.Null_Object_Id;
+            P.State := Available;
+            P.Name := (others => ' ');
+            P.Shared_Pages := (others => (0, 0));
+         end;
       end loop;
 
       Current_Process := Process_Table (1)'Access;
@@ -438,7 +443,7 @@ package body Rose.Kernel.Processes.Init is
          Proc.Page_Ranges (Invocation_Range_Index) :=
            (Virtual_Address_To_Page (Invocation_Buffer_Range_Base),
             Virtual_Address_To_Page (Invocation_Buffer_Range_Bound));
-         Proc.Invocation_Buffer :=
+         Proc.Shared_Pages (1).Page :=
            Proc.Page_Ranges (Invocation_Range_Index).Base;
 
          Proc.Directory_Page :=

--- a/src/kernel/processes/rose-kernel-processes.ads
+++ b/src/kernel/processes/rose-kernel-processes.ads
@@ -293,7 +293,7 @@ package Rose.Kernel.Processes is
       Virtual_Page  : Rose.Addresses.Virtual_Page_Address);
 
    procedure Unmap_Invocation_Buffer
-     (Pid : Process_Id);
+     (From_Pid, To_Pid : Process_Id);
 
    function Mapped_Physical_Page
      (Pid          : Process_Id;
@@ -432,6 +432,20 @@ private
 
    subtype Process_Name is String (1 .. 16);
 
+   type Shared_Page_Record is
+      record
+         Page : Virtual_Page_Address;
+         Pid  : Process_Id;
+      end record;
+
+   Max_Shared_Pages : constant := 4;
+   type Shared_Page_Count is range 0 .. Max_Shared_Pages;
+   subtype Shared_Page_Index is
+     Shared_Page_Count range 1 .. Shared_Page_Count'Last;
+
+   type Shared_Page_Array is
+     array (Shared_Page_Index) of Shared_Page_Record;
+
    type Kernel_Process_Entry is
       record
          Stack             : Rose.Kernel.Arch.Stack_Frame;
@@ -473,7 +487,7 @@ private
          Data_Page         : Rose.Addresses.Physical_Page_Address;
          Stack_Page        : Rose.Addresses.Physical_Page_Address;
          Env_Page          : Rose.Addresses.Physical_Page_Address;
-         Invocation_Buffer : Rose.Addresses.Virtual_Page_Address;
+         Shared_Pages      : Shared_Page_Array;
          Saved_Stack_Value : Rose.Words.Word_32;
       end record;
 


### PR DESCRIPTION
If process A invokes a capability for process B, and sends a buffer along, the kernel maps the buffer into the address space of B.
Old behaviour: unmap the buffer after a reply message from B
New behaviour: unmap the buffer after a reply message from B to A