### PR TITLE
73: fully allocate boot module memory

### DIFF
--- a/src/kernel/processes/rose-kernel-processes-init.adb
+++ b/src/kernel/processes/rose-kernel-processes-init.adb
@@ -183,6 +183,7 @@ package body Rose.Kernel.Processes.Init is
                   else
                      if Have_Process_Handlers
                        and then Enable_Paging
+                       and then False
                      then
                         --  we can page
                         Heap_Addr :=
@@ -244,6 +245,7 @@ package body Rose.Kernel.Processes.Init is
                   if not Writable
                     or else not Have_Process_Handlers
                     or else not Enable_Paging
+                    or else True
                   then
                      Prealloc := Memory_Size;
                   else


### PR DESCRIPTION
This avoids page faults in tricky situations